### PR TITLE
Fix versioning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keyscope"
-version = "1.2.0"
+version = "1.2.3"
 edition = "2018"
 build = "build.rs"
 


### PR DESCRIPTION
https://github.com/SpectralOps/keyscope/issues/20
Fixed version + 1 to bump for new release tag.