### PR TITLE
Add Infura API key validation

### DIFF
--- a/src/defs.yaml
+++ b/src/defs.yaml
@@ -22,6 +22,22 @@ providers:
         err:
           status_code: "500"
 
+  infura:
+    validation:
+      request:
+        id: "infura:validation"
+        desc: "infura API key"
+        params:
+        - name: infura_1
+          desc: infura API key
+        uri: https://mainnet.infura.io/v3/{{infura_1}}
+        body: '{"jsonrpc": "2.0", "id": 1, "method": "eth_blockNumber", "params": []}'
+        method: post
+      response:
+        body: "^((?!invalid project id).)*$"
+      invalid:
+        status_code: "5\\d\\d"
+
   covalenthq:
     validation:
       request:


### PR DESCRIPTION
Add [Infura](https://infura.io/) provider API key validation.
API documentation can be found [here](https://docs.infura.io/infura/networks/ethereum/how-to/make-requests)

Sample API request taken from Infura docs:
[https://docs.infura.io/infura/networks/ethereum/how-to/make-requests#curl-or-wscat](https://docs.infura.io/infura/networks/ethereum/how-to/make-requests#curl-or-wscat)
<img width="765" alt="image" src="https://user-images.githubusercontent.com/44297242/199623709-5932c427-151b-400e-89e8-7a888e77a179.png">

