### PR TITLE
add bazaarvoice API

### DIFF
--- a/src/defs.yaml
+++ b/src/defs.yaml
@@ -846,3 +846,17 @@ providers:
         status_code: "200"
       invalid:
         status_code: "5\\d\\d"
+
+  bazaarvoice:
+    validation:
+      request:
+        id: "bazaarvoice:validation"
+        desc: "Bazaarvoice: valid key"
+        params:
+        - name: bazaarvoice_1
+          desc: bazaarvoice token
+        uri: https://which-cpv-api.bazaarvoice.com/clientInfo?conversationspasskey={{bazaarvoice_1}}
+      response:
+        status_code: "200"
+      invalid:
+        status_code: "4\\d\\d"


### PR DESCRIPTION
Needs openssl option passed to allow for bad cert
```
cargo run validate bazaarvoice -p 1234a                                                                                                           [git][keyscope/.][bazaarvoiceU]
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/keyscope validate bazaarvoice -p 1234a`

    __                                       
   / /_____  __  ________________  ____  ___ 
  / // / _ \/ / / / ___/ ___/ __ \/ __ \/ _ \
 /   </  __/ /_/ (__  ) /__/ /_/ / /_/ /  __/
/_/|_|\___/\__, /____/\___/\____/ .___/\___/ 
          (____/               /_/
                    keyscope 1.2.3

• bazaarvoice:validation: started
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Utf8Error { valid_up_to: 2, error_len: Some(1) }', /home/bober/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.10.36/src/error.rs:223:40
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```